### PR TITLE
Add settings file, CLI args, and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ The interface contains two tabs:
 1. **Image Classifier** – choose an image and the model will annotate the detected faces.
 2. **Video Classifier** – start the webcam feed and view the predicted expressions in real time.
 
+### Settings
+
+You can provide a `settings.json` file in the project root to configure the model path and video source. The default file looks like:
+
+```json
+{
+  "model_path": "models/Trained_Model.keras",
+  "video_source": 0
+}
+```
+
+Command-line options override the file:
+
+```bash
+python main.py --model-path path/to/model --video-source 1
+```
+
 ### Example: Image Classification
 
 ![Example image classification](images/image_classification_example.jpg)

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,4 @@
+{
+  "model_path": "models/Trained_Model.keras",
+  "video_source": 0
+}

--- a/src/facial_expression/image_classifier_tab.py
+++ b/src/facial_expression/image_classifier_tab.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLabel, QFileDialog
+from PyQt6.QtWidgets import QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLabel, QFileDialog, QMessageBox
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QImage, QPixmap
 from PIL import Image
@@ -42,7 +42,11 @@ class ImageClassifierTab(QWidget):
         if file_path:
             self.selected_image_path = file_path
             self.input_image = Image.open(self.selected_image_path)
-            self.output_image = Image.fromarray(classify(np.array(self.input_image)))
+            try:
+                self.output_image = Image.fromarray(classify(np.array(self.input_image)))
+            except Exception as e:
+                QMessageBox.critical(self, "Classification Error", str(e))
+                return
             self.update_images()
 
     def update_images(self):

--- a/src/facial_expression/main.py
+++ b/src/facial_expression/main.py
@@ -1,13 +1,26 @@
 import sys
+import argparse
+import json
+import os
 from PyQt6.QtWidgets import QApplication, QMainWindow, QTabWidget
 from PyQt6.QtGui import QIcon
 from PyQt6.QtCore import Qt
 from video_classifier_tab import VideoClassifierTab
 from image_classifier_tab import ImageClassifierTab
+from Classifier import set_model_path
+from paths import MODEL_PATH as DEFAULT_MODEL_PATH
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Facial Expression Recognition GUI")
+    parser.add_argument("--settings", default="settings.json", help="Path to JSON settings file")
+    parser.add_argument("--model-path", help="Path to trained model")
+    parser.add_argument("--video-source", help="Video source index or file path")
+    return parser.parse_args()
 
 
 class MainApplication(QMainWindow):
-    def __init__(self):
+    def __init__(self, video_source=0):
         super().__init__()
         self.setWindowTitle("Facial Expression Recognition Client")
 
@@ -19,7 +32,7 @@ class MainApplication(QMainWindow):
         self.tab_control = QTabWidget(self)
         self.setCentralWidget(self.tab_control)
 
-        self.video_classifier = VideoClassifierTab()
+        self.video_classifier = VideoClassifierTab(video_source=video_source)
         self.image_classifier = ImageClassifierTab()
 
         self.tab_control.addTab(self.video_classifier, "Video Classifier")
@@ -35,7 +48,26 @@ class MainApplication(QMainWindow):
 
 
 if __name__ == "__main__":
+    args = parse_args()
+    settings = {}
+    if os.path.exists(args.settings):
+        try:
+            with open(args.settings, "r") as f:
+                settings = json.load(f)
+        except Exception as e:
+            print(f"Failed to read settings file: {e}")
+
+    model_path = args.model_path or settings.get("model_path", DEFAULT_MODEL_PATH)
+    video_source = args.video_source if args.video_source is not None else settings.get("video_source", 0)
+
+    try:
+        video_source = int(video_source)
+    except (TypeError, ValueError):
+        pass
+
+    set_model_path(model_path)
+
     app = QApplication(sys.argv)
-    main_window = MainApplication()
+    main_window = MainApplication(video_source=video_source)
     main_window.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- allow overriding model path and video source using `settings.json` or command line options
- catch model loading and camera errors in GUI and classifier
- show classification errors in the image and video tabs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(within venv)*

------
https://chatgpt.com/codex/tasks/task_e_6853891d72a083338ef0b8b227a15b0c